### PR TITLE
Add DALI support for faster data loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,17 @@ $ conda activate byol
 $ python main.py
 ```
 
+### Optional: Install NVIDIA DALI for faster data loading
+```
+pip install nvidia-dali-cuda120
+```
+For more information, follow the official guide: https://docs.nvidia.com/deeplearning/dali/user-guide/docs/installation.html
+
 ## Config
 
 Before running PyTorch BYOL, make sure you choose the correct running configurations on the config.yaml file.
+
+To run the training with [NVIDIA DALI](https://docs.nvidia.com/deeplearning/dali/user-guide/docs/index.html), select the configuration file `config/config_dali.yaml`.
 
 ```yaml
 network:
@@ -44,6 +52,9 @@ optimizer:
     lr: 0.03
     momentum: 0.9
     weight_decay: 0.0004
+
+dali:
+  enabled: false
 ```
 
 ## Feature Evaluation

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -24,3 +24,6 @@ optimizer:
     lr: 0.03
     momentum: 0.9
     weight_decay: 0.0004
+
+dali:
+  enabled: false

--- a/config/config_dali.yaml
+++ b/config/config_dali.yaml
@@ -30,4 +30,4 @@ optimizer:
 
 dali:
   enabled: true
-  reader_name: ImgReader
+  reader_name: ImgReader # Needed to avoid indefinite looping over the dataset (ref https://docs.nvidia.com/deeplearning/dali/user-guide/docs/index.html)

--- a/config/config_dali.yaml
+++ b/config/config_dali.yaml
@@ -1,0 +1,33 @@
+network:
+  name: resnet18
+
+  # Specify a folder containing a pre-trained model to fine-tune. If training from scratch, pass None.
+  fine_tune_from: 'resnet-18_40-epochs'
+
+  projection_head:
+    mlp_hidden_size: 512
+    projection_size: 128
+
+dataset:
+  root: datasets/exposure_rated/ratings
+
+data_transforms:
+  s: 1
+  input_shape: (224,224,3)
+
+trainer:
+  batch_size: 64
+  m: 0.996 # momentum update
+  checkpoint_interval: 5000
+  max_epochs: 40
+  num_workers: 4
+
+optimizer:
+  params:
+    lr: 0.03
+    momentum: 0.9
+    weight_decay: 0.0004
+
+dali:
+  enabled: true
+  reader_name: ImgReader

--- a/config/config_dali.yaml
+++ b/config/config_dali.yaml
@@ -9,7 +9,7 @@ network:
     projection_size: 128
 
 dataset:
-  root: datasets/exposure_rated/ratings
+  root: /path/to/dataset # This should follow the same structure of the ImageFolder dataset
 
 data_transforms:
   s: 1

--- a/data/dali_iterator.py
+++ b/data/dali_iterator.py
@@ -10,11 +10,10 @@ class DALIGenericIteratorWithViews(DALIGenericIterator):
         data = data[0]
 
         views = []
-        for view in self.output_map:
-            if view not in data:
-                raise ValueError(f"View {view} not found in the output data.")
-            views.append(data[view])
-        return views
+        for output_key in self.output_map:
+            if "view" in output_key:
+                views.append(data[output_key])
+        return views, data["label"]
 
     def __len__(self):
         """Return the number of iterations per epoch."""

--- a/data/dali_iterator.py
+++ b/data/dali_iterator.py
@@ -1,0 +1,24 @@
+from nvidia.dali.plugin.pytorch import DALIGenericIterator
+
+
+class DALIGenericIteratorWithViews(DALIGenericIterator):
+    def __init__(self, pipelines, output_map, size=-1, reader_name=None):
+        super().__init__(pipelines, output_map, size, reader_name=reader_name)
+
+    def __next__(self):
+        data = super().__next__()  # Get the batch of preprocessed images
+        data = data[0]
+
+        views = []
+        for view in self.output_map:
+            if view not in data:
+                raise ValueError(f"View {view} not found in the output data.")
+            views.append(data[view])
+        return views
+
+    def __len__(self):
+        """Return the number of iterations per epoch."""
+        # The following assumes there are more DALI pipelines. In our case there is only one
+        samples_per_pipe = [sum(pipe.epoch_size().values()) for pipe in self._pipes]
+        total_samples = sum(samples_per_pipe)
+        return total_samples // self.batch_size

--- a/data/dali_pipeline.py
+++ b/data/dali_pipeline.py
@@ -31,7 +31,7 @@ def read_images(
         interp_type=types.INTERP_TRIANGULAR,
     )
 
-    return images
+    return images, labels
 
 
 def random_grayscale(images, p=0.2):
@@ -105,7 +105,7 @@ def simclr_dali_transforms(images, image_size=224):
 
 @pipeline_def(enable_conditionals=True)
 def simclr_dali_pipeline(image_dir, shuffle=True, image_size=224, reader_name="Reader"):
-    images = read_images(image_dir, shuffle, reader_name=reader_name)
+    images, labels = read_images(image_dir, shuffle, reader_name=reader_name)
     view1 = simclr_dali_transforms(images, image_size=image_size)
     view2 = simclr_dali_transforms(images, image_size=image_size)
-    return view1, view2
+    return view1, view2, labels

--- a/data/dali_pipeline.py
+++ b/data/dali_pipeline.py
@@ -1,0 +1,111 @@
+import math
+
+import nvidia.dali.fn as fn
+import nvidia.dali.types as types
+from nvidia.dali import pipeline_def
+
+
+def read_images(
+    image_dir, shuffle=True, device="mixed", crop_size=224, reader_name="Reader"
+):
+    preallocate_width_hint = 5980 if device == "mixed" else 0
+    preallocate_height_hint = 6430 if device == "mixed" else 0
+
+    images, labels = fn.readers.file(
+        file_root=image_dir, random_shuffle=shuffle, name=reader_name
+    )
+    images = fn.decoders.image_random_crop(
+        images,
+        device=device,
+        output_type=types.RGB,
+        preallocate_width_hint=preallocate_width_hint,
+        preallocate_height_hint=preallocate_height_hint,
+        random_aspect_ratio=[0.8, 1.25],
+        random_area=[0.1, 1.0],
+        num_attempts=100,
+    )
+    images = fn.resize(
+        images,
+        resize_x=crop_size,
+        resize_y=crop_size,
+        interp_type=types.INTERP_TRIANGULAR,
+    )
+
+    return images
+
+
+def random_grayscale(images, p=0.2):
+    if fn.random.coin_flip(probability=p):
+        out = fn.color_space_conversion(
+            images, image_type=types.RGB, output_type=types.GRAY
+        )
+        out = fn.color_space_conversion(
+            out, image_type=types.GRAY, output_type=types.RGB
+        )  # Restore 3 channels
+    else:
+        out = images
+    return out
+
+
+def gaussian_blur(images, kernel_size):
+    image_size = images.shape()[0]
+    kernel_size = math.ceil(int(0.1 * image_size))
+    images = fn.gaussian_blur(
+        images,
+        window_size=(kernel_size, kernel_size),
+        sigma=fn.random.uniform(range=[0, 1]),
+    )
+
+
+def color_jitter(images):
+    b_factor = fn.random.uniform(range=[max(0, 1 - 0.8), 1 + 0.8])
+    c_factor = fn.random.uniform(range=[max(0, 1 - 0.8), 1 + 0.8])
+    s_factor = fn.random.uniform(range=[max(0, 1 - 0.8), 1 + 0.8])
+    h_factor = fn.random.uniform(range=[-0.2 * 360, 0.2 * 360])
+    images = fn.color_twist(
+        images,
+        brightness=b_factor,
+        contrast=c_factor,
+        saturation=s_factor,
+        hue=h_factor,
+    )
+    return images
+
+
+def solarize(images, threshold=0.5):
+    if fn.random.coin_flip(probability=0.1):
+        inverted_img = types.Constant(255, dtype=types.UINT8) - images
+        mask = images >= threshold * 255
+        out = mask * inverted_img + (True ^ mask) * images
+    else:
+        out = images
+    return out
+
+
+def simclr_dali_transforms(images, image_size=224):
+    images = fn.flip(images, horizontal=fn.random.coin_flip(probability=0.5))
+    if fn.random.coin_flip(probability=0.8):
+        images = color_jitter(images)
+    images = random_grayscale(images, p=0.2)
+    kernel_size = int(math.ceil(0.1 * image_size))
+    images = fn.gaussian_blur(
+        images,
+        window_size=(kernel_size, kernel_size),
+        sigma=fn.random.uniform(range=[0, 1]),
+    )
+    if solarize:
+        images = solarize(images, threshold=0.5)
+
+    # Reshape the tensor from HWC to CHW layout
+    images = fn.transpose(images, output_layout="CHW", perm=[2, 0, 1])
+    images = fn.cast(images, dtype=types.FLOAT)
+
+    return images
+
+
+@pipeline_def(enable_conditionals=True)
+def simclr_dali_pipeline(image_dir, shuffle=True, image_size=224, reader_name="Reader"):
+    images = read_images(image_dir, shuffle, reader_name=reader_name)
+    view1 = simclr_dali_transforms(images, image_size=image_size)
+    view2 = simclr_dali_transforms(images, image_size=image_size)
+    return view1, view2

--- a/main.py
+++ b/main.py
@@ -2,7 +2,11 @@ import os
 
 import torch
 import yaml
+from torch.utils.data.dataloader import DataLoader
 from torchvision import datasets
+
+from data.dali_pipeline import simclr_dali_pipeline
+from data.dali_iterator import DALIGenericIteratorWithViews
 from data.multi_view_data_injector import MultiViewDataInjector
 from data.transforms import get_simclr_data_transforms
 from models.mlp_head import MLPHead
@@ -19,11 +23,20 @@ def main():
     device = 'cuda' if torch.cuda.is_available() else 'cpu'
     print(f"Training with: {device}")
 
-    data_transform = get_simclr_data_transforms(**config['data_transforms'])
-
-    train_dataset = datasets.STL10('/home/thalles/Downloads/', split='train+unlabeled', download=True,
+    if config['dali']['enabled']:
+        dali_pipeline = simclr_dali_pipeline(config['dataset']['root'], batch_size=config['trainer']['batch_size'],
+                                           num_threads=config['trainer']['num_workers'], device_id=0, reader_name=config['dali']['reader_name'],
+                                           image_size=eval(config['data_transforms']['input_shape'])[0], shuffle=True)
+        dali_pipeline.build()
+        train_loader = DALIGenericIteratorWithViews(dali_pipeline, ['view1', 'view2', "label"], reader_name=config['dali']['reader_name'])
+    else:
+        data_transform = get_simclr_data_transforms(**config['data_transforms'])
+        train_dataset = datasets.STL10('/home/thalles/Downloads/', split='train+unlabeled', download=True,
                                    transform=MultiViewDataInjector([data_transform, data_transform]))
-
+        train_loader = DataLoader(train_dataset, batch_size=config['trainer']['batch_size'],
+                                num_workers=config['trainer']['num_workers'], drop_last=False, shuffle=True)
+    
+    
     # online network
     online_network = ResNet18(**config['network']).to(device)
     pretrained_folder = config['network']['fine_tune_from']
@@ -59,7 +72,7 @@ def main():
                           device=device,
                           **config['trainer'])
 
-    trainer.train(train_dataset)
+    trainer.train(train_loader)
 
 
 if __name__ == '__main__':

--- a/trainer.py
+++ b/trainer.py
@@ -77,7 +77,7 @@ class BYOLTrainer:
                 niter += 1
             
             if len(batch_view_1) != self.batch_size:
-                n_images = len(train_loader) - 1 * self.batch_size + len(batch_view_1)
+                n_images = (len(train_loader) - 1) * self.batch_size + len(batch_view_1)
             else:
                 n_images = len(train_loader) * self.batch_size
             avg_speed = int(n_images / (time.time() - start))

--- a/trainer.py
+++ b/trainer.py
@@ -1,8 +1,9 @@
 import os
+import time
+
 import torch
 import torch.nn.functional as F
 import torchvision
-from torch.utils.data.dataloader import DataLoader
 from torch.utils.tensorboard import SummaryWriter
 
 from utils import _create_model_training_folder
@@ -43,13 +44,11 @@ class BYOLTrainer:
             param_k.data.copy_(param_q.data)  # initialize
             param_k.requires_grad = False  # not update by gradient
 
-    def train(self, train_dataset):
-
-        train_loader = DataLoader(train_dataset, batch_size=self.batch_size,
-                                  num_workers=self.num_workers, drop_last=False, shuffle=True)
+    def train(self, train_loader):
 
         niter = 0
         model_checkpoints_folder = os.path.join(self.writer.log_dir, 'checkpoints')
+        start = time.time()
 
         self.initializes_target_network()
 
@@ -76,8 +75,14 @@ class BYOLTrainer:
 
                 self._update_target_network_parameters()  # update the key encoder
                 niter += 1
-
-            print("End of epoch {}".format(epoch_counter))
+            
+            if len(batch_view_1) != self.batch_size:
+                n_images = len(train_loader) - 1 * self.batch_size + len(batch_view_1)
+            else:
+                n_images = len(train_loader) * self.batch_size
+            avg_speed = int(n_images / (time.time() - start))
+            start = time.time()
+            print("End of epoch {}\t{} img/s".format(epoch_counter, avg_speed))
 
         # save checkpoints
         self.save_model(os.path.join(model_checkpoints_folder, 'model.pth'))


### PR DESCRIPTION
As stated in #16, loading data with PyTorch DataLoaders results in slow execution and bad GPU utilization, caused by the augmentations applied to multiple views of each image.

This PR implements an alternative data loader, beside the original one, that uses the [NVIDIA DALI library](https://developer.nvidia.com/dali), which moves the augmentations and data loading operations to the GPU and provides a speedup of about 5x (~500 img/s with DALI vs ~110 img/s with the PyTorch dataloader, same batch size, same number of threads/workers).